### PR TITLE
Variable Renaming and Removal of non-null assertion operator

### DIFF
--- a/src/commands/voice.ts
+++ b/src/commands/voice.ts
@@ -111,11 +111,11 @@ const command: Command = {
 
 		const subcommand = interaction.options.getSubcommand(true);
 
-		const isOwner = partyChannelOwners.get(voiceChannel.id) !== interaction.member.id;
+		const isNotOwner = partyChannelOwners.get(voiceChannel.id) !== interaction.member.id;
 
 		switch (subcommand) {
 			case "name": {
-				if (isOwner) {
+				if (isNotOwner) {
 					await interaction.reply({
 						embeds: [
 							{
@@ -236,7 +236,7 @@ const command: Command = {
 				break;
 			}
 			case "lock": {
-				if (isOwner) {
+				if (isNotOwner) {
 					await interaction.reply({
 						embeds: [
 							{
@@ -248,8 +248,7 @@ const command: Command = {
 					});
 					return;
 				}
-
-				const locked = partyChannelLocks.get(voiceChannel.id)!;
+				const locked = partyChannelLocks.has(voiceChannel.id) ?? false;
 
 				const shouldLock = interaction.options.getBoolean("shouldlock", true);
 

--- a/src/commands/voice.ts
+++ b/src/commands/voice.ts
@@ -248,9 +248,10 @@ const command: Command = {
 					});
 					return;
 				}
-				const locked = partyChannelLocks.has(voiceChannel.id) ?? false;
 
 				const shouldLock = interaction.options.getBoolean("shouldlock", true);
+				
+				const locked = partyChannelLocks.get(voiceChannel.id) ?? !shouldLock;
 
 				if (locked === shouldLock) {
 					await interaction.reply({


### PR DESCRIPTION
Changes
+ I renamed the `isOwner` variable to `isNotOwner` so it is clearer.
+ I also replaced the non-null assertion operator on the locked variable as if it returns a null or undefined it would cause a runtime error. 
So now if it is "null or undefined" it will assign the opposite of `shouldLock` resulting in the channel being set back to the Map so it can be used in the future.